### PR TITLE
ci: fix pipeline to run docker-build on push to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Run tests
         run: npm test
 
-
   build-check:
     name: Build (Check only)
     runs-on: ubuntu-latest
@@ -73,8 +72,7 @@ jobs:
   docker-build:
     name: Build & Push Docker
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    needs: [lint, test, build-check]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
- Updated ci/cd.yml so lint/test/build-check run only on pull_request
- Changed docker-build to run independently on push to main
- Left deploy-prod.yaml and deploy-staging.yml unchanged